### PR TITLE
error display is smaller, profile is responsive

### DIFF
--- a/src/Pages/Profile/Profile.css
+++ b/src/Pages/Profile/Profile.css
@@ -1,0 +1,5 @@
+@media screen and (min-width: 600px) {
+  .profile-input {
+    width: 400px !important;
+  }
+}

--- a/src/Pages/Profile/Profile.js
+++ b/src/Pages/Profile/Profile.js
@@ -5,6 +5,7 @@ import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import axios from "axios";
+import "./Profile.css";
 
 const Profile = () => {
   const [isEdittingAccount, setIsEdittingAccount] = useState(false);
@@ -115,7 +116,7 @@ const Profile = () => {
       <AccountCircleIcon
         sx={{ fontSize: 120, color: "grey", alignSelf: "start", flex: 1 }}
       />
-      <Box sx={{ flex: 4 }}>
+      <Box sx={{ flex: 4, marginBottom: "50vh" }}>
         <Typography component="h1" variant="h3">
           Profile
         </Typography>
@@ -127,10 +128,11 @@ const Profile = () => {
             sx={{ mt: 1 }}
           >
             <TextField
+              className="profile-input"
               margin="normal"
               required
               fullWidth
-              sx={{ width: "400px", display: "block" }}
+              sx={{ display: "block" }}
               name="name"
               label="Full Name"
               type="text"
@@ -139,10 +141,11 @@ const Profile = () => {
               autoFocus
             />
             <TextField
+              className="profile-input"
               margin="normal"
               required
               fullWidth
-              sx={{ width: "400px", display: "block" }}
+              sx={{ display: "block" }}
               id="email"
               label="Email Address"
               name="email"
@@ -175,10 +178,11 @@ const Profile = () => {
             sx={{ mt: 1 }}
           >
             <TextField
+              className="profile-input"
               margin="normal"
               required
               fullWidth
-              sx={{ width: "400px", display: "block" }}
+              sx={{ display: "block" }}
               name="password"
               label="Current Password"
               type="password"
@@ -187,10 +191,11 @@ const Profile = () => {
               autoFocus
             />
             <TextField
+              className="profile-input"
               margin="normal"
               required
               fullWidth
-              sx={{ width: "400px", display: "block" }}
+              sx={{ display: "block" }}
               id="new-password"
               label="New Password"
               name="new-password"
@@ -199,10 +204,11 @@ const Profile = () => {
               onChange={handleNewPasswordChange}
             />
             <TextField
+              className="profile-input"
               margin="normal"
               required
               fullWidth
-              sx={{ width: "400px", display: "block" }}
+              sx={{ display: "block" }}
               id="confirm-password"
               label="Confirm New Password"
               name="confirm-password"
@@ -210,7 +216,7 @@ const Profile = () => {
               helperText={invalidConfirmPasswordMessage}
               onChange={handleConfirmPasswordChange}
             />
-            {error && <p className="error-msg">{errorMessage}</p>}
+            {error && <p className="error-msg profile-input">{errorMessage}</p>}
             <Button
               disabled={isNewPasswordInvalid || isConfirmPasswordInvalid}
               type="submit"
@@ -235,8 +241,8 @@ const Profile = () => {
           </Box>
         ) : (
           <Box>
-            <Typography sx={{ width: "400px" }}>Name: {user.name}</Typography>
-            <Typography sx={{ width: "400px" }}>Email: {user.email}</Typography>
+            <Typography>Name: {user.name}</Typography>
+            <Typography>Email: {user.email}</Typography>
             <Button
               onClick={() => setIsEdittingAccount(true)}
               variant="outlined"
@@ -245,6 +251,7 @@ const Profile = () => {
                 mb: 2,
                 display: "inline",
                 height: "50px",
+                fontSize: "0.68rem",
                 backgroundColor: "black",
                 color: "white",
                 "&:hover": {
@@ -260,9 +267,10 @@ const Profile = () => {
               sx={{
                 mt: 3,
                 mb: 2,
-                ml: 2,
+                ml: 1,
                 display: "inline",
                 height: "50px",
+                fontSize: "0.68rem",
                 backgroundColor: "black",
                 color: "white",
                 "&:hover": {


### PR DESCRIPTION
## Description
<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? -->
Make error display area smaller
Profile page is responsive now

## Resouce links or research articles
<!-- What did I learn anything worth sharing like links or sites which I researched ? -->

## Related Issue
<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->
closes #138 

## Acceptance Criteria
<!-- Include AC from the Github issue -->
Error displays on a smaller banner
Profile page is responsive on mobile

## Type of Changes
<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|    | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
<!-- If UI feature, take provide screenshots -->
<img width="954" alt="Screen Shot 2022-12-06 at 2 22 39 PM" src="https://user-images.githubusercontent.com/88150284/206400455-e82c3f79-e65a-49d0-a06c-faf234c5e013.png">


### After
<!-- If UI feature, take provide screenshots -->
<img width="618" alt="Screen Shot 2022-12-08 at 12 37 15 AM" src="https://user-images.githubusercontent.com/88150284/206400348-c6d0b041-21a8-4ac7-8ee2-c2a7bd85595e.png">
<img width="313" alt="Screen Shot 2022-12-08 at 12 37 24 AM" src="https://user-images.githubusercontent.com/88150284/206400363-182b8fb4-f54a-423d-bc19-4ece17a3909e.png">


## Testing Steps / QA Criteria
<!-- Provide steps the other team members and mentors need to follow to properly test your additions. -->
